### PR TITLE
Update sync_dir script and added env variables to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       - PGID=1000
       - TZ=Europe/Paris
       - UMASK=022 #optional
+      - THRESHOLD_MINUTES=5
+      - TRANSFER_FILE_TYPE=.cbz
     ports:
       - 3000:3000
     volumes:

--- a/root/usr/local/bin/sync_dir
+++ b/root/usr/local/bin/sync_dir
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-# Function to monitor changes using find with -cmin and sync with rsync
-
 monitor_changes() {
-    while true; do
-        echo "Monitoring..."
-        if [ -z "$(find "$1" -type f -cmin -"$THRESHOLD_MINUTES")" ]; then
-            echo "No files modified in the last $THRESHOLD_MINUTES minutes, executing."
-            rsync -avm --include='*/' --include=*"$TRANSFER_FILE_TYPE" --exclude='*' --remove-source-files  "$1"/ "$2"
-        fi
-        sleep 30
-    done
+
+	copied_files=""
+
+	while true; do
+		while IFS= read -r file; do
+			case "$copied_files" in
+				*"${file}"*)
+					;;
+				*)
+					rsync -av "$file" "$2/$(basename "$(dirname "$file")")/"
+					copied_files="${copied_files}${file}
+"
+					;;
+			esac
+		done < <(find "$1" -type f -name *"$TRANSFER_FILE_TYPE")
+
+		find "$1" -mindepth 1 -type d -cmin +"$THRESHOLD_MINUTES" -exec rm -r {} \;
+
+		sleep 20
+	done
 }
 
 monitor_changes "$1" "$2" &

--- a/root/usr/local/bin/sync_dir
+++ b/root/usr/local/bin/sync_dir
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-# Function to monitor changes using inotifywait and sync with rsync
-rsync -avz "$1"/ "$2"
+# Function to monitor changes using find with -cmin and sync with rsync
+
 monitor_changes() {
-    while inotifywait -r -e modify,create,delete,move "$1"/; do
-        rsync -avz "$1"/ "$2"
+    while true; do
+        echo "Monitoring..."
+        if [ -z "$(find "$1" -type f -cmin -"$THRESHOLD_MINUTES")" ]; then
+            echo "No files modified in the last $THRESHOLD_MINUTES minutes, executing."
+            rsync -avm --include='*/' --include=*"$TRANSFER_FILE_TYPE" --exclude='*' --remove-source-files  "$1"/ "$2"
+        fi
+        sleep 30
     done
 }
 


### PR DESCRIPTION
this updated script runs a check every 30 seconds if a file in /app/FMD2/downloads has been modified in the last 5 minutes (the amount of time can be modified).

If a file was recently modified then sleep for 30 seconds and then run the check again

If a file was not recently modified run the rsync command provided by @Nitrousoxide https://github.com/Banh-Canh/docker-FMD2/issues/13#issuecomment-1891087908
which copies the file(s) to /downloads and then removes them from /app/FMD2/downloads


The only issue i see with this script is that if the container stops unexpectedly during big jobs data loss may occur. 
Perhaps it could be modified to copy .cbz files as they become available but only remove the source after THRESHOLD_MINUTES of no file activity, so it doesn't cause any errors internally for FMD.
I played around with that for a bit but i didn't get anything working consistently, maybe someone else has better knowledge.